### PR TITLE
Use new settings package to better manage default settings

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -12,3 +12,4 @@ accounts-password
 less
 joshowens:shareit
 tap:i18n
+ogourment:settings

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -51,6 +51,7 @@ mongo@1.0.11
 mrt:moment@2.8.1
 npm-bcrypt@0.7.7
 observe-sequence@1.0.4
+ogourment:settings@1.0.0
 ordered-dict@1.0.2
 random@1.0.2
 reactive-dict@1.0.5

--- a/app/client/route.js
+++ b/app/client/route.js
@@ -1,5 +1,11 @@
 (function () {
 
+  'use strict';
+
+  MeteorSettings.setDefaults({ public: {
+    blog: { defaultLocale: "en" }
+  }});
+
   Router.configure({
     layoutTemplate: 'mainLayout'
   });

--- a/src/client/blog-client.js
+++ b/src/client/blog-client.js
@@ -1,25 +1,15 @@
 (function () {
 
-  var defaultBlogSettings = {
-    "blogPath": "/blog",
-    "archivePath": "/blog/archive",
-    "useUniqueBlogPostsPath": true,
-    "prettify": {
-      "syntax-highlighting": true
-    },
-    "defaultLocale": "en"
-  };
-
-  if (!Meteor.settings || !Meteor.settings.public || !Meteor.settings.public.blog) {
-    Meteor.settings = Meteor.settings || {};
-    Meteor.settings.public = Meteor.settings.public || {};
-    Meteor.settings.public.blog = defaultBlogSettings;
-  } else {
-    _.defaults(Meteor.settings.public.blog, defaultBlogSettings);
-  }
-
   'use strict';
 
+  MeteorSettings.setDefaults({ public:
+    { blog:
+      { "blogPath": "/blog",
+        "archivePath": "/blog/archive",
+        "useUniqueBlogPostsPath": true
+      }
+    }
+  });
 
   var momentLocaleDep = new Tracker.Dependency;
 

--- a/src/client/blog-route.js
+++ b/src/client/blog-route.js
@@ -1,5 +1,9 @@
 (function () {
 
+  'use scrict';
+
+  MeteorSettings.setDefaults({ public: { blog: {} }});
+
   var blogSub = Meteor.subscribe('blog');
 
   function getBaseBlogPath () {

--- a/src/package.js
+++ b/src/package.js
@@ -11,7 +11,7 @@ Package.on_use(function (api) {
 
   // APIs
   api.use(['meteor-platform@1.2.0', 'less@1.0.11']);
-  api.use(['spiderable@1.0.5', 'less@1.0.11']);
+  api.use(['spiderable@1.0.5']);
   api.use(['reactive-var@1.0.3'], ['client', 'server']);
   api.use(['iron:router@1.0.0'], ['client', 'server']);
   api.use(['chuangbo:marked@0.3.5'], ['client', 'server']);
@@ -20,6 +20,7 @@ Package.on_use(function (api) {
   api.use(['alanning:roles@1.2.13'], ['client', 'server']);
   api.use(['fortawesome:fontawesome@4.2.0_2'], ['client']);
   api.use(['tap:i18n@1.3.1'], ['client', 'server']);
+  api.use('ogourment:settings');
 
   // Common
   api.add_files(['common/blog-collections.js'], ['client', 'server']);

--- a/src/server/blog-server.js
+++ b/src/server/blog-server.js
@@ -2,6 +2,10 @@
 
   'use strict';
 
+  MeteorSettings.setDefaults({ public: {
+    blog: { defaultLocale: "en" }
+  }}, MeteorSettings.REQUIRED);
+
   Meteor.publish('blog', function () {
     if (Roles.userIsInRole(this.userId, ['mdblog-author'])) {
       return Blog.find();
@@ -92,6 +96,5 @@
       });
     }
   });
-
 
 })();


### PR DESCRIPTION
- server raises an error if no settings.json are provided
- defaults are modular. Only provide the defaults that are used in the js file
- provide sensible defaults when not provided (no longer all-or-nothing)
  Example: if `settings.json` does not contain `blogPath`, fall back to the "/blog" default.